### PR TITLE
feat(definitions): Added `DLQMessageVisible`  for DeadLetterQueue

### DIFF
--- a/src/defaults/definitions.js
+++ b/src/defaults/definitions.js
@@ -2,6 +2,7 @@
 
 const lambdaNamespace = 'AWS/Lambda';
 const APIGatewayNamespace = 'AWS/ApiGateway';
+const SQSNamespace = 'AWS/SQS';
 
 module.exports = {
   functionInvocations: {
@@ -203,6 +204,29 @@ module.exports = {
       evaluationPeriods: 1,
       comparisonOperator: 'LessThanThreshold',
       ...definitions,
+    };
+  },
+  DLQMessageVisible: functionObj => {
+    const dlqName = functionObj.alarmDLQName;
+    if (!dlqName) {
+      throw new Error('Alarm DLQ Name (alarmDLQName) is required.');
+    }
+    const dimensions = [{
+      Name: "QueueName",
+      Value: dlqName,
+    }];
+    return {
+      omitDefaultDimension: true,
+      namespace: SQSNamespace,
+      description: 'Messages present in DLQ',
+      metric: 'ApproximateNumberOfMessagesVisible',
+      threshold: 1,
+      statistic: 'Sum',
+      dimensions,
+      period: 60,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+      comparisonOperator: 'GreaterThanOrEqualToThreshold',
     };
   },
 };

--- a/src/defaults/definitions.js
+++ b/src/defaults/definitions.js
@@ -206,7 +206,7 @@ module.exports = {
       ...definitions,
     };
   },
-  DLQMessageVisible: functionObj => {
+  DLQMessageVisible: definitions => functionObj => {
     const dlqName = functionObj.alarmDLQName;
     if (!dlqName) {
       throw new Error('Alarm DLQ Name (alarmDLQName) is required.');
@@ -227,6 +227,7 @@ module.exports = {
       evaluationPeriods: 1,
       datapointsToAlarm: 1,
       comparisonOperator: 'GreaterThanOrEqualToThreshold',
+      ...definitions,
     };
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -27,11 +27,7 @@ class AlertsPlugin {
   }
 
   getDefinitions(config) {
-    const configDefinitions = config.definitions;
-    if (!configDefinitions) {
-      return defaultDefinitions;
-    }
-
+    const configDefinitions = config.definitions || {};
     return Object.keys(defaultDefinitions)
       .reduce((acc, definitionName) => {
         const definition = defaultDefinitions[definitionName];


### PR DESCRIPTION
##  How to use
```yaml
handler: ......
alarmDLQName:
   "Fn::GetAtt": [ DLDName, QueueName ]
alarms:
   - DLQMessageVisible
```

**alarmDLQName** is the name of dead letter queue