### PR TITLE
feature(alerts): Add S3 NumberOfObjects Alarm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ublend-npm/serverless-plugin-aws-alerts",
-  "version": "1.5.14",
+  "version": "1.5.15",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/src/defaults/definitions.js
+++ b/src/defaults/definitions.js
@@ -3,6 +3,7 @@
 const lambdaNamespace = 'AWS/Lambda';
 const APIGatewayNamespace = 'AWS/ApiGateway';
 const SQSNamespace = 'AWS/SQS';
+const S3Namespace = 'AWS/S3';
 
 module.exports = {
   functionInvocations: {
@@ -263,4 +264,28 @@ module.exports = {
       ...definitions,
     };
   },
+  NumberOfObjectsInBucket: definitions => (functionName, serverless) => {
+    const functionObj = serverless.service.getFunction(functionName);
+    const bucketName = functionObj.alarmBucketName;
+
+    const dimensions = [{
+      Name: 'BucketName',
+      Value: bucketName
+    }]
+
+    return {
+      omitDefaultDimension: true,
+      namespace: S3Namespace,
+      description: 'Objects present in the bucket',
+      metric: 'NumberOfObjects',
+      threshold: 100000,
+      statistic: 'Sum',
+      dimensions,
+      period: 3600,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+      comparisonOperator: 'GreaterThanOrEqualToThreshold',
+      ...definitions,
+    };
+  }
 };

--- a/src/defaults/definitions.js
+++ b/src/defaults/definitions.js
@@ -267,6 +267,7 @@ module.exports = {
   NumberOfObjectsInBucket: definitions => (functionName, serverless) => {
     const functionObj = serverless.service.getFunction(functionName);
     const bucketName = functionObj.alarmBucketName;
+    const threshold = functionObj.alarmBucketObjectsThreshold || 100000;
 
     const dimensions = [{
       Name: 'BucketName',
@@ -278,7 +279,7 @@ module.exports = {
       namespace: S3Namespace,
       description: 'Objects present in the bucket',
       metric: 'NumberOfObjects',
-      threshold: 100000,
+      threshold,
       statistic: 'Sum',
       dimensions,
       period: 3600,


### PR DESCRIPTION
# Description

Introduce  S3 `NumberOfObjects` alarm needed for analytics ingestion pipeline [monitoring](https://github.com/AulaEducation/aula/pull/8102#discussion_r444730368).