### PR TITLE
feat(alerts): Introduce Redis Available Memory alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ublend-npm/serverless-plugin-aws-alerts",
-  "version": "1.5.17-beta.0",
+  "version": "1.5.17",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ublend-npm/serverless-plugin-aws-alerts",
-  "version": "1.5.16",
+  "version": "1.5.17-beta.0",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/src/defaults/definitions.js
+++ b/src/defaults/definitions.js
@@ -314,7 +314,7 @@ module.exports = {
     return {
       omitDefaultDimension: true,
       namespace: ElastiCacheNamespace,
-      description: 'Available memory in the Redis node',
+      description: 'Used memory of the Redis node',
       metric: 'DatabaseMemoryUsagePercentage',
       threshold,
       statistic: 'Maximum',

--- a/src/defaults/definitions.js
+++ b/src/defaults/definitions.js
@@ -299,7 +299,7 @@ module.exports = {
     const functionObj = serverless.service.getFunction(functionName);
     const cacheClusterId = functionObj.alarmRedisCacheClusterId;
     const cacheNodeId = functionObj.alarmRedisCacheNodeId || '0001';
-    const threshold = functionObj.alarmRedisFreeMemoryThreshold || 60;
+    const threshold = functionObj.alarmRedisFreeMemoryThreshold || 70;
 
     const dimensions = [
       {
@@ -314,7 +314,7 @@ module.exports = {
     return {
       omitDefaultDimension: true,
       namespace: ElastiCacheNamespace,
-      description: 'Used memory of the Redis node',
+      description: 'Used memory percentage of the Redis node',
       metric: 'DatabaseMemoryUsagePercentage',
       threshold,
       statistic: 'Maximum',

--- a/src/defaults/definitions.js
+++ b/src/defaults/definitions.js
@@ -4,6 +4,7 @@ const lambdaNamespace = 'AWS/Lambda';
 const APIGatewayNamespace = 'AWS/ApiGateway';
 const SQSNamespace = 'AWS/SQS';
 const S3Namespace = 'AWS/S3';
+const ElastiCacheNamespace = 'AWS/ElastiCache';
 
 module.exports = {
   functionInvocations: {
@@ -270,14 +271,14 @@ module.exports = {
     const threshold = functionObj.alarmBucketObjectsThreshold || 100000;
 
     const dimensions = [
-    {
-      Name: 'BucketName',
-      Value: bucketName
-    },
-    {
-      Name: 'StorageType',
-      Value: 'AllStorageTypes'
-    }]
+      {
+        Name: 'BucketName',
+        Value: bucketName
+      },
+      {
+        Name: 'StorageType',
+        Value: 'AllStorageTypes'
+      }]
 
     return {
       omitDefaultDimension: true,
@@ -288,6 +289,37 @@ module.exports = {
       statistic: 'Average',
       dimensions,
       period: 86400,
+      evaluationPeriods: 1,
+      datapointsToAlarm: 1,
+      comparisonOperator: 'GreaterThanOrEqualToThreshold',
+      ...definitions,
+    };
+  },
+  RedisMemoryUsagePercentage: definitions => (functionName, serverless) => {
+    const functionObj = serverless.service.getFunction(functionName);
+    const cacheClusterId = functionObj.alarmRedisCacheClusterId;
+    const cacheNodeId = functionObj.alarmRedisCacheNodeId || '0001';
+    const threshold = functionObj.alarmRedisFreeMemoryThreshold || 60;
+
+    const dimensions = [
+      {
+        Name: 'CacheClusterId',
+        Value: cacheClusterId
+      },
+      {
+        Name: 'CacheNodeId',
+        Value: cacheNodeId,
+      }]
+
+    return {
+      omitDefaultDimension: true,
+      namespace: ElastiCacheNamespace,
+      description: 'Available memory in the Redis node',
+      metric: 'DatabaseMemoryUsagePercentage',
+      threshold,
+      statistic: 'Maximum',
+      dimensions,
+      period: 300,
       evaluationPeriods: 1,
       datapointsToAlarm: 1,
       comparisonOperator: 'GreaterThanOrEqualToThreshold',


### PR DESCRIPTION
# Description

Alert for `ElastiCache` `DatabaseMemoryUsagePercentage` Metric.

The alarm is configured via three alert properties:
- `alarmRedisCacheClusterId` - ElastiCache Cluster Id (usually `${inst}-cache-001`) 
- `alarmRedisCacheNodeId` - ElastiCache Node Id (usually (defaulted) `0001` ) 
- `alarmRedisFreeMemoryThreshold` - Percentage threshold (GTE) on which the alarm will trigger (defaulted to 70)

The created alarm will trigger if the provided threshold has been crossed for the *maximum* observed metric value in  a *5 minute* period.