### PR TITLE
chore: Add plugin configuration types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ublend-npm/serverless-plugin-aws-alerts",
-  "version": "1.7.0",
+  "version": "2.0.0",
   "description": "",
   "main": "src/index.js",
   "scripts": {
@@ -16,7 +16,7 @@
   "author": "John McKim <john@acloud.guru>",
   "license": "MIT",
   "peerDependencies": {
-    "serverless": "^1.12.0"
+    "serverless": "^3.26.0"
   },
   "dependencies": {
     "lodash": "^4.17.10"

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,12 @@ class AlertsPlugin {
     this.hooks = {
       'package:compileEvents': this.compile.bind(this),
     };
+
+    this.serverless.configSchemaHandler.defineFunctionProperties('aws', {
+      properties: {
+        alarms: { type: 'array' },
+      },
+    });
   }
 
   getConfig() {


### PR DESCRIPTION
# Technical Context
The latest version of Serverless (`3.26.0`) displays warnings in the case that the plugin does not specify it's configuration variables and types. Currently, this is only displayed as a warning, but in future versions of Serverless, the default behaviour will be changed to `error`.

This PR adds the needed types for this plugin.

[Deployment](https://app.circleci.com/pipelines/github/AulaEducation/aula/73485/workflows/b8144f23-64c1-47ee-a00b-ea053551c997/jobs/131654) with a [beta version](https://github.com/AulaEducation/aula/compare/master...chore/sls-upgrade-test-deployment#diff-0d17cc9ee20492da686c95538d9910386573a0b3333642b70e2256cff2f1874aR26) tested without warnings. 

## Changelog
<!--
 List the changes that this PR is bringing to the platform, making it as understandable as possible to anyone in the company.
 Please don't remove the code block.
 -->

```changelog
- Chore: Specify plugin configuration variables and types. 
```

## Loom/Screenshot
<!--
 A loom with a walkthrough of the changes (or even of the PR when it's complex!)
 is always highly appreciated as it provides context to the reviewer.

 If it's a small visual change, a screenshot might be enough :)
 -->

## Review Guideline Cheatsheet

> Please refer to [this doc](https://www.notion.so/aulaeducation/Pull-Request-Guidelines-7a0e0465554a4b479636bfd439d19e4b) for the complete PR review guideline.

Emoji | Intention
---|---
🍰 `:cake:` | Nice to have, but not blocking
💡 `:bulb:` | Refactor suggestion or another idea that require relevant changes and may need a discussion
🤔 `:thinking:` | Something is not clear, can you give me more context?
🔨 `:hammer:` | Required change
🚀 `:rocket:` | Positive feedback