### PR TITLE
Add missing types for Notification service alarms

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,10 @@ class AlertsPlugin {
         inheritGlobalAlarms: { type: 'boolean' },
         alarmDLQName: { type: 'object' },
         alarmBucketName: { type: 'string' },
-        alarmBucketObjectsThreshold: { type: 'number' }
+        alarmBucketObjectsThreshold: { type: 'number' },
+        alarmRedisCacheClusterId: { type: 'string' },
+        alarmRedisFreeMemoryThreshold: { type: 'number' },
+        cacheNodeId: { type: 'string' }
       },
     });
   }


### PR DESCRIPTION
## What did you implement:
Add missing alarm types for notifications service 


<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:


## How can we verify it:
### Pre-changes
<img width="956" alt="image" src="https://user-images.githubusercontent.com/32667622/215542901-3781a7dd-e772-4920-b683-97047b405695.png">

### Post-changes
<img width="756" alt="image" src="https://user-images.githubusercontent.com/32667622/215542945-b710c3ec-f0ec-42dc-bb3a-4d679bf4d2d5.png">



<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* Screenshots - Showing the difference between your output and the master
* Other - Anything else that comes to mind to help us evaluate
-->


## Todos:

[] Write tests
[] Write documentation
[] Fix linting errors
[] Provide verification config/commands/resources

