### PR TITLE
bugfix(AULA-1986): Include definitions in functionAvailability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ublend-npm/serverless-plugin-aws-alerts",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "",
   "main": "src/index.js",
   "scripts": {

--- a/src/defaults/definitions.js
+++ b/src/defaults/definitions.js
@@ -27,7 +27,7 @@ module.exports = {
     datapointsToAlarm: 1,
     comparisonOperator: 'GreaterThanOrEqualToThreshold',
   },
-  functionAvailability: () => (functionName, serverless) => {
+  functionAvailability: definitions => (functionName, serverless) => {
     const namingProvider = serverless.getProvider('aws').naming;
     const funRef = namingProvider.getLambdaLogicalId(functionName);
 
@@ -94,6 +94,7 @@ module.exports = {
       datapointsToAlarm: 2,
       comparisonOperator: 'LessThanThreshold',
       treatMissingData: 'notBreaching',
+      ...definitions,
     };
   },
   functionDuration: {


### PR DESCRIPTION
This PR fixes the issue where alerts were not being triggered correctly for the functionAvailability alarm when the serverless template included alarm definitions. The reason for the bug was that the functionAvailability function wasn't including the definitions in the returned value, like the other 

The draft version of this change was tested in the file-uploader service, where the issue was originally discovered. The alarm was triggered successfully for the image resize lambda:
![image](https://github.com/user-attachments/assets/54229558-c8cb-40ef-bfab-8b51721d3b67)
![Screenshot 2024-07-12 at 15 55 20](https://github.com/user-attachments/assets/98e18aad-7a78-4071-ab94-24d4593b50ed)
